### PR TITLE
Expose google group to git

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ $ pulumi config set vault:token hvs..... --secret
 
 $ pulumi config set ggl:client_id 1051431507099-i2d83aiogb0c349go9si6j8ahuv5p6ml.apps.googleusercontent.com
 $ pulumi config set ggl:client_secret ... --secret
+$ pulumi config set ggl:vault_sa_account_json '{...json...}' --secret
 ```

--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ $ pulumi config set vault:token hvs..... --secret
 $ pulumi config set ggl:client_id 1051431507099-i2d83aiogb0c349go9si6j8ahuv5p6ml.apps.googleusercontent.com
 $ pulumi config set ggl:client_secret ... --secret
 $ pulumi config set ggl:vault_sa_account_json '{...json...}' --secret
+$ pulumi config set ggl:gsuite_admin 'sysadmin [@] hul.to'
 ```

--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ $ pulumi config set ggl:client_id 1051431507099-i2d83aiogb0c349go9si6j8ahuv5p6ml
 $ pulumi config set ggl:client_secret ... --secret
 $ pulumi config set ggl:vault_sa_account_json '{...json...}' --secret
 $ pulumi config set ggl:gsuite_admin 'sysadmin [@] hul.to'
+$ pulumi config set ggl:gsuite_domain 'hul.to'
 ```

--- a/src/2_app/__main__.py
+++ b/src/2_app/__main__.py
@@ -8,6 +8,7 @@ import pulumi_vault as pvault
 from shared.vault.auth_method import AuthMethodJWT
 from shared.vault.oidc_provider import OIDCProvider
 from shared.git.git import Gitea
+from shared.vault.group_external import GroupExternal
 
 def main():
     print("Starting")
@@ -63,6 +64,15 @@ def main():
         name="gitea-auth",
         redirect_uris=["http://localhost:3000/user/oauth2/vault/callback", "https://openidconnect.net/callback"],
         scope_template=google_auth.auth_accessor.apply(lambda accessor: gen_accessor_template(accessor) ))
+
+    # Setup labadmins group
+    lab_admins = GroupExternal(
+        name="labadmins",
+        group_name="labadmins@hul.to",
+        policies=["admin","default"],
+        metadata={"organization": "Lab administrators"},
+        auth_mount_accessor=google_auth.auth_accessor)
+
 
     pulumi.export("client_id", gitea_oidc.client_id)
     pulumi.export("client_secret", gitea_oidc.client_secret)

--- a/src/2_app/__main__.py
+++ b/src/2_app/__main__.py
@@ -73,6 +73,13 @@ def main():
         metadata={"organization": "Lab administrators"},
         auth_mount_accessor=google_auth.auth_accessor)
 
+    red_team = GroupExternal(
+        name="redteam",
+        group_name="red-team@hul.to",
+        policies=["default"],
+        metadata={"organization": "Red teamers"},
+        auth_mount_accessor=google_auth.auth_accessor)
+
 
     pulumi.export("client_id", gitea_oidc.client_id)
     pulumi.export("client_secret", gitea_oidc.client_secret)

--- a/src/2_app/__main__.py
+++ b/src/2_app/__main__.py
@@ -1,5 +1,6 @@
 """A Python Pulumi program"""
 
+import os
 import pulumi
 import pulumi_vault as pvault
 
@@ -9,6 +10,16 @@ from shared.git.git import Gitea
 
 def main():
     print("Starting")
+
+    # Create vault policies
+    policies_dir = "../shared/vault/policies"
+    for policy_file in os.listdir(policies_dir):
+        with open(f"{policies_dir}/{policy_file}", 'r') as f:
+            name = policy_file.removesuffix(".hcl")
+            pvault.Policy(
+                resource_name=f"policy-{name}",
+                name=name,
+                policy=f.read())
 
     # Setup vault google auth method
     google_auth = AuthMethodJWT(

--- a/src/2_app/__main__.py
+++ b/src/2_app/__main__.py
@@ -50,7 +50,8 @@ def main():
             "email": "email",
             "groups": "groups",
             "given_name": "nickname",
-        })
+        },
+        user_claim="email")
 
     # Setup vault oidc provider for gitea
     def gen_accessor_template(accessor: str):

--- a/src/2_app/__main__.py
+++ b/src/2_app/__main__.py
@@ -1,5 +1,6 @@
 """A Python Pulumi program"""
 
+import json
 import os
 import pulumi
 import pulumi_vault as pvault
@@ -21,17 +22,47 @@ def main():
                 name=name,
                 policy=f.read())
 
+    config = pulumi.Config("ggl")
+    sa_secret = config.require("vault_sa_account_json")
+    sa_email = json.loads(sa_secret)["client_email"]
+    gsuite_admin = config.require("gsuite_admin")
+    gsuite_domain = config.require("gsuite_domain")
+
     # Setup vault google auth method
     google_auth = AuthMethodJWT(
         name="google-auth",
         path="oidc",
         desc="Authenticate to lab using GSuite account",
-        discover_url="https://accounts.google.com")
+        discover_url="https://accounts.google.com",
+        oidc_scopes=["openid","email","profile"],
+        provider_config={
+            "provider": "gsuite",
+            "gsuite_service_account": sa_secret,
+            "gsuite_admin_impersonate": gsuite_admin,
+            "fetch_groups": True,
+            "domain": gsuite_domain,
+            "fetch_user_info": True,
+            "groups_recurse_max_depth": 5,
+            "impersonate_principal": sa_email,
+        },
+        claim_mappings={
+            "email": "email",
+            "groups": "groups",
+            "given_name": "nickname",
+        })
 
     # Setup vault oidc provider for gitea
+    def gen_accessor_template(accessor: str):
+        return f"""{{ 
+    "username":{{{{identity.entity.aliases.{accessor}.name}}}},
+    "groups": {{{{identity.entity.groups.names}}}},
+    "email": {{{{identity.entity.aliases.{accessor}.metadata.email}}}},
+    "nickname": {{{{identity.entity.aliases.{accessor}.metadata.nickname}}}}
+}}"""
     gitea_oidc = OIDCProvider(
         name="gitea-auth",
-        redirect_uris=["http://localhost:3000/user/oauth2/vault/callback"])
+        redirect_uris=["http://localhost:3000/user/oauth2/vault/callback", "https://openidconnect.net/callback"],
+        scope_template=google_auth.auth_accessor.apply(lambda accessor: gen_accessor_template(accessor) ))
 
     pulumi.export("client_id", gitea_oidc.client_id)
     pulumi.export("client_secret", gitea_oidc.client_secret)

--- a/src/shared/git/git.py
+++ b/src/shared/git/git.py
@@ -16,6 +16,15 @@ class Gitea(pulumi.ComponentResource):
         self.dns_zone = dns_zone
         super().__init__('ggl:shared/git:Gitea', name, None, opts)
 
+        """
+        Icon URL - https://www.datocms-assets.com/2885/1676497447-vault-favicon-color.png?h=32&w=32
+        OpenID Connect Auto Discovery URL - https://vault.galaxygridlabs.com/v1/identity/oidc/provider/gitea-auth/.well-known/openid-configuration
+        Additional Scopes - gitea-auth openid profile email
+        Claim name providing group names for this source. (Optional) - groups
+        Group Claim value for administrator users. (Optional - requires claim name above) - labadmins@hul.to
+        Map claimed groups to Organization teams. (Optional - requires claim name above) - {"red-team@hul.to":{"red-team":["red-teamers"]}}
+        """
+
     @property
     def name(self):
         return self.__name

--- a/src/shared/git/git.py
+++ b/src/shared/git/git.py
@@ -23,6 +23,16 @@ class Gitea(pulumi.ComponentResource):
         Claim name providing group names for this source. (Optional) - groups
         Group Claim value for administrator users. (Optional - requires claim name above) - labadmins@hul.to
         Map claimed groups to Organization teams. (Optional - requires claim name above) - {"red-team@hul.to":{"red-team":["red-teamers"]}}
+
+        docker run --rm -p 3000:3000 -v gitdata:/data \
+            -e GITEA__openid__ENABLE_OPENID_SIGNIN=true \
+            -e GITEA__openid__ENABLE_OPENID_SIGNUP=true \
+            -e GITEA__oauth2_client__ENABLE_AUTO_REGISTRATION=true \
+            -e GITEA__oauth2_client__ACCOUNT_LINKING=auto \
+            -e "GITEA__oauth2_client__OPENID_CONNECT_SCOPES=gitea-auth openid" \
+            -e USER_UID=1000 -e USER_GID=1000 \
+            --name gitea-test docker.io/gitea/gitea:1.22.3@sha256:76f516a1a8c27e8f8e9773639bf337c0176547a2d42a80843e3f2536787341c6 
+
         """
 
     @property

--- a/src/shared/vault/auth_method.py
+++ b/src/shared/vault/auth_method.py
@@ -18,11 +18,12 @@ class AuthMethodJWT(pulumi.ComponentResource):
 
         # Set and validate vars from config
         vault_config = pulumi.Config("vault")
-        self.vault_address = vault_config.require("address")    
+        self.vault_address = vault_config.require("address")
 
         config = pulumi.Config("ggl")
         client_id = config.require("client_id")
-        client_secret = config.require("client_secret")    
+        client_secret = config.require("client_secret")
+        sa_secret = config.require("vault_sa_account_json")
 
 
         # Setup vault google auth method
@@ -36,17 +37,70 @@ class AuthMethodJWT(pulumi.ComponentResource):
             default_role=oidc_default_role,
             oidc_client_id=client_id,
             oidc_client_secret=client_secret,
+            provider_config={
+                "provider": "gsuite",
+                "gsuite_service_account": sa_secret,
+                "gsuite_admin_impersonate": "hulto@hul.to",
+                "fetch_groups": True,
+                "domain": "hul.to",
+                "fetch_user_info": True,
+                "groups_recurse_max_depth": 5,
+                "impersonate_principal": "vault-core-40809eee975c@galaxygridlabs.iam.gserviceaccount.com",
+            },
             opts=pulumi.ResourceOptions(parent=self))
 
         self.oidc_redirect_uri = f"{self.vault_address}/ui/vault/auth/{self.path}/oidc/callback"
         pvault.jwt.AuthBackendRole(
             resource_name=name,
             backend=google_auth_method.path,
-            user_claim="sub",
+            user_claim="email",
+            groups_claim="groups",
             role_name=oidc_default_role,
             token_policies=["default"],
-            allowed_redirect_uris=[self.oidc_redirect_uri],
+            oidc_scopes=["openid","email"],
+            allowed_redirect_uris=[
+                self.oidc_redirect_uri,
+                "http://localhost:8250/oidc/callback",
+            ],
+            claim_mappings={
+                "email": "email",
+                "picture": "pfp",
+                "groups": "groups",
+            },
             opts=pulumi.ResourceOptions(parent=self))
+
+        # https://developer.hashicorp.com/vault/docs/auth/jwt/oidc-providers/google
+        # Go to console.cloud.google.com
+        # IAM & Admin > Service accounts > vault-core-... > Advanced Settings > Domain-wide delegation
+        # Copy the client ID `108356764425394966944`
+        # Click "View google workspace admin console"
+        # ... > Security > Access and data control > API controls > Domain wide delegation > Add new
+        # Paste ID
+        # Paste scopes: `https://www.googleapis.com/auth/admin.directory.group.readonly https://www.googleapis.com/auth/admin.directory.user.readonly`
+        # Generate service account credentials save them store them to config secret
+
+        # https://developer.hashicorp.com/vault/tutorials/auth-methods/identity#create-an-external-group
+       
+        #  hulto@saw  /tmp/test5 
+        # $ vault write -format=json identity/group name="labadmins@hul.to" \
+        #     policies="admin" \
+        #     type="external" \
+        #     metadata=organization="Lab administrators" | jq -r ".data.id" > group_id.txt
+
+
+        #  hulto@saw  /tmp/test5 
+        # $ cat group_id.txt 
+        # ee87ad9c-5b71-1911-2ba9-4b28a794ce40
+
+        #  hulto@saw  /tmp/test5 
+        # $ vault write identity/group-alias name="labadmins@hul.to" \
+        #     mount_accessor="auth_oidc_53f0016e" \
+        #     canonical_id="ee87ad9c-5b71-1911-2ba9-4b28a794ce40"
+
+        # Key             Value
+        # ---             -----
+        # canonical_id    ee87ad9c-5b71-1911-2ba9-4b28a794ce40
+        # id              5f0a4040-5fee-abaf-687b-eab54f6aab69
 
 
     @property

--- a/src/shared/vault/auth_method.py
+++ b/src/shared/vault/auth_method.py
@@ -73,26 +73,6 @@ class AuthMethodJWT(pulumi.ComponentResource):
 
         # https://developer.hashicorp.com/vault/tutorials/auth-methods/identity#create-an-external-group
 
-        lab_admins = pvault.identity.Group(
-           resource_name=name,
-            name="labadmins@hul.to",
-            type="external",
-            policies=[
-                "admin",
-                "default",
-            ],
-            metadata={
-                "organization": "Lab administrators",
-            },
-            opts=pulumi.ResourceOptions(parent=self))
-
-        group_alias = pvault.identity.GroupAlias(
-            resource_name=f"{name}-alias",
-            name="labadmins@hul.to",
-            mount_accessor=google_auth_method.accessor,
-            canonical_id=lab_admins.id,
-            opts=pulumi.ResourceOptions(parent=self))
-
 
     @property
     def name(self):

--- a/src/shared/vault/auth_method.py
+++ b/src/shared/vault/auth_method.py
@@ -27,6 +27,7 @@ class AuthMethodJWT(pulumi.ComponentResource):
         sa_secret = config.require("vault_sa_account_json")
         sa_email = json.loads(sa_secret)["client_email"]
         gsuite_admin = config.require("gsuite_admin")
+        gsuite_domain = config.require("gsuite_domain")
 
 
         # Setup vault google auth method
@@ -45,7 +46,7 @@ class AuthMethodJWT(pulumi.ComponentResource):
                 "gsuite_service_account": sa_secret,
                 "gsuite_admin_impersonate": gsuite_admin,
                 "fetch_groups": True,
-                "domain": "hul.to",
+                "domain": gsuite_domain,
                 "fetch_user_info": True,
                 "groups_recurse_max_depth": 5,
                 "impersonate_principal": sa_email,

--- a/src/shared/vault/auth_method.py
+++ b/src/shared/vault/auth_method.py
@@ -13,6 +13,8 @@ class AuthMethodJWT(pulumi.ComponentResource):
                 provider_config: dict,
                 oidc_scopes: List[str],
                 claim_mappings: dict,
+                user_claim: str = "sub",
+                groups_claim: str = "groups",
                 opts = None):
 
         super().__init__('ggl:shared/vault:AuthMethodJWT', name, None, opts)
@@ -47,8 +49,8 @@ class AuthMethodJWT(pulumi.ComponentResource):
         pvault.jwt.AuthBackendRole(
             resource_name=name,
             backend=google_auth_method.path,
-            user_claim="email",
-            groups_claim="groups",
+            user_claim=user_claim,
+            groups_claim=groups_claim,
             role_name=oidc_default_role,
             token_policies=["default"],
             oidc_scopes=oidc_scopes,

--- a/src/shared/vault/group_external.py
+++ b/src/shared/vault/group_external.py
@@ -1,0 +1,29 @@
+import pulumi_vault as pvault
+import pulumi
+from typing import List
+
+class GroupExternal(pulumi.ComponentResource):
+    def __init__(self,
+                name: str,
+                group_name: str,
+                policies: List[str],
+                metadata: dict,
+                auth_mount_accessor: str,
+                opts = None):
+
+        super().__init__('ggl:shared/vault:GroupExternal', name, None, opts)
+
+        group = pvault.identity.Group(
+            resource_name=name,
+            name=group_name,
+            type="external",
+            policies=policies,
+            metadata=metadata,
+            opts=pulumi.ResourceOptions(parent=self))
+
+        group_alias = pvault.identity.GroupAlias(
+            resource_name=f"{name}-alias",
+            name=group_name,
+            mount_accessor=auth_mount_accessor,
+            canonical_id=group.id,
+            opts=pulumi.ResourceOptions(parent=self))

--- a/src/shared/vault/oidc_provider.py
+++ b/src/shared/vault/oidc_provider.py
@@ -10,6 +10,7 @@ class OIDCProvider(pulumi.ComponentResource):
     def __init__(self,
                 name: str,
                 redirect_uris: List[str],
+                scope_template: pulumi.Output,
                 opts = None):
 
         super().__init__('ggl:shared/vault:OIDCProvider', name, None, opts)
@@ -36,10 +37,8 @@ class OIDCProvider(pulumi.ComponentResource):
         scope = pvault.identity.OidcScope(
             resource_name=name,
             name=name,
-            template=json.dumps({
-                "groups": "{{identity.entity.groups.names}}",
-            }),
-            description=f"Scopes for the {name} oidc provider")
+            template=scope_template,
+            description=f"Scope for the {name} oidc provider")
         
         issuer_host = self.vault_address.split("://")[1]
         provider = pvault.identity.OidcProvider(

--- a/src/shared/vault/policies/admin.hcl
+++ b/src/shared/vault/policies/admin.hcl
@@ -1,0 +1,59 @@
+# Read system health check
+path "sys/health"
+{
+  capabilities = ["read", "sudo"]
+}
+
+# Create and manage ACL policies broadly across Vault
+
+# List existing policies
+path "sys/policies/acl"
+{
+  capabilities = ["list"]
+}
+
+# Create and manage ACL policies
+path "sys/policies/acl/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Enable and manage authentication methods broadly across Vault
+
+# Manage auth methods broadly across Vault
+path "auth/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Create, update, and delete auth methods
+path "sys/auth/*"
+{
+  capabilities = ["create", "update", "delete", "sudo"]
+}
+
+# List auth methods
+path "sys/auth"
+{
+  capabilities = ["read"]
+}
+
+# Enable and manage the key/value secrets engine at `secret/` path
+
+# List, create, update, and delete key/value secrets
+path "secret/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Manage secrets engines
+path "sys/mounts/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# List existing secrets engines.
+path "sys/mounts"
+{
+  capabilities = ["read"]
+}


### PR DESCRIPTION
- Allow users to auth and register to gitea using vault ---> google OIDC
- Auto fill username and email for new users based on google user metadata
- Auto assign admin in gitea to users in the `labadmins` google group
- Auto assign admin policy in vault to users in the `labadmins` google group
- Auto assign the red-teamers team in `red-team` git org to users in the `red-team` google group